### PR TITLE
Updates to support / enforce proper Image Resource structure

### DIFF
--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/Html5SmartImage.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/Html5SmartImage.java
@@ -57,27 +57,12 @@ public @interface Html5SmartImage {
 	 */
 	public boolean disableZoom() default false;
 
-    /**
-     * Indicates that this component represents the image itself and as such the image properties
-     * and file assets should be stored on the component's resource instead of a child resource
-     */
-    public boolean isSelf() default false;
-
 	/**
-	 * Name of the form field used for posting the file name.
-	 *
-	 * @return String
+	 * Indicates that this component represents the image itself and as such the
+	 * image properties and file assets should be stored on the component's
+	 * resource instead of a child resource
 	 */
-	public String fileNameParameter() default "fileName";
-
-    /**
-     * The name of the child node under which the image itself will be stored in cases where the image is uploaded
-     * via the widget.  Defaults to "file" in keeping with the default of the com.day.cq.commons.DownloadResource
-     * class.
-     *
-     * @return String
-     */
-    public String fileName() default "file";
+	public boolean isSelf() default false;
 
 	/**
 	 * Path to which files will be uploaded.

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/Html5SmartImage.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/Html5SmartImage.java
@@ -57,6 +57,12 @@ public @interface Html5SmartImage {
 	 */
 	public boolean disableZoom() default false;
 
+    /**
+     * Indicates that this component represents the image itself and as such the image properties
+     * and file assets should be stored on the component's resource instead of a child resource
+     */
+    public boolean isSelf() default false;
+
 	/**
 	 * Name of the form field used for posting the file name.
 	 *
@@ -64,12 +70,14 @@ public @interface Html5SmartImage {
 	 */
 	public String fileNameParameter() default "fileName";
 
-	/**
-	 * The field's HTML name attribute
-	 *
-	 * @return String
-	 */
-	public String name() default "";
+    /**
+     * The name of the child node under which the image itself will be stored in cases where the image is uploaded
+     * via the widget.  Defaults to "file" in keeping with the default of the com.day.cq.commons.DownloadResource
+     * class.
+     *
+     * @return String
+     */
+    public String fileName() default "file";
 
 	/**
 	 * Path to which files will be uploaded.

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidget.java
@@ -27,6 +27,9 @@ import com.citytechinc.cq.component.dialog.TabbableDialogElement;
 public class Html5SmartImageWidget extends AbstractWidget implements TabbableDialogElement {
 	public static final String XTYPE = "html5smartimage";
 	private String originalName;
+    private String namePrefix;
+    private final String fileName;
+	private final boolean isSelf;
 	private final boolean disableFlush;
 	private final boolean disableInfo;
 	private final boolean disableZoom;
@@ -45,6 +48,9 @@ public class Html5SmartImageWidget extends AbstractWidget implements TabbableDia
 	public Html5SmartImageWidget(Html5SmartImageWidgetParameters parameters) {
 		super(parameters);
 		originalName = parameters.getName();
+        this.namePrefix = "";
+        this.fileName = parameters.getFileName();
+        this.isSelf = parameters.isSelf();
 		this.disableFlush = parameters.isDisableFlush();
 		this.disableInfo = parameters.isDisableInfo();
 		this.disableZoom = parameters.isDisableZoom();
@@ -60,13 +66,21 @@ public class Html5SmartImageWidget extends AbstractWidget implements TabbableDia
 		this.tab = parameters.isTab();
 	}
 
-	private static String getNameAsPrefix(String name) {
-		if (StringUtils.isEmpty(name)) {
-			return "./";
+	private String getNamePrefix() {
+		if (StringUtils.isEmpty(originalName) || isSelf) {
+			return "./" + namePrefix;
 		} else {
-			return "./" + name + "/";
+			return "./" + namePrefix + originalName + "/";
 		}
 	}
+
+	private String getFileName() {
+        if (fileName == null) {
+            return "";
+        }
+
+        return fileName;
+    }
 
 	public String getTitle() {
 		return title;
@@ -90,35 +104,35 @@ public class Html5SmartImageWidget extends AbstractWidget implements TabbableDia
 
 	public String getCropParameter() {
 		if (!StringUtils.isEmpty(cropParameter)) {
-			return getNameAsPrefix(originalName) + cropParameter;
+			return getNamePrefix() + cropParameter;
 		}
 		return cropParameter;
 	}
 
 	public String getFileNameParameter() {
 		if (!StringUtils.isEmpty(fileNameParameter)) {
-			return getNameAsPrefix(originalName) + fileNameParameter;
+			return getNamePrefix() + fileNameParameter;
 		}
 		return fileNameParameter;
 	}
 
 	public String getFileReferenceParameter() {
 		if (!StringUtils.isEmpty(fileReferenceParameter)) {
-			return getNameAsPrefix(originalName) + fileReferenceParameter;
+			return getNamePrefix() + fileReferenceParameter;
 		}
 		return fileReferenceParameter;
 	}
 
 	public String getMapParameter() {
 		if (!StringUtils.isEmpty(mapParameter)) {
-			return getNameAsPrefix(originalName) + mapParameter;
+			return getNamePrefix() + mapParameter;
 		}
 		return mapParameter;
 	}
 
 	public String getRotateParameter() {
 		if (!StringUtils.isEmpty(rotateParameter)) {
-			return getNameAsPrefix(originalName) + rotateParameter;
+			return getNamePrefix() + rotateParameter;
 		}
 		return rotateParameter;
 	}
@@ -148,16 +162,19 @@ public class Html5SmartImageWidget extends AbstractWidget implements TabbableDia
 	}
 
 	public String getRequestSuffix() {
-		if (StringUtils.isEmpty(originalName)) {
+		if (StringUtils.isEmpty(originalName) || isSelf) {
+            if (StringUtils.isNotEmpty(namePrefix)) {
+                return "/" + namePrefix + ".img.png";
+            }
 			return ".img.png";
 		} else {
-			return "/" + originalName + ".img.png";
+			return "/" + namePrefix + originalName + ".img.png";
 		}
 	}
 
 	@Override
 	public String getName() {
-		return getNameAsPrefix(originalName);
+		return getNamePrefix() + getFileName();
 	}
 
 	@Override
@@ -169,6 +186,11 @@ public class Html5SmartImageWidget extends AbstractWidget implements TabbableDia
 		if (name.endsWith("/")) {
 			newName = newName.substring(0, newName.length() - 1);
 		}
-		originalName = newName;
+        if (name.endsWith(originalName)) {
+            namePrefix = newName.substring(0, newName.indexOf(originalName));
+        }
+        else {
+            originalName = newName;
+        }
 	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidget.java
@@ -27,9 +27,7 @@ import com.citytechinc.cq.component.dialog.TabbableDialogElement;
 public class Html5SmartImageWidget extends AbstractWidget implements TabbableDialogElement {
 	public static final String XTYPE = "html5smartimage";
 	private String originalName;
-    private String namePrefix;
-    private final String fileName;
-	private final boolean isSelf;
+	private final String fileName;
 	private final boolean disableFlush;
 	private final boolean disableInfo;
 	private final boolean disableZoom;
@@ -48,9 +46,7 @@ public class Html5SmartImageWidget extends AbstractWidget implements TabbableDia
 	public Html5SmartImageWidget(Html5SmartImageWidgetParameters parameters) {
 		super(parameters);
 		originalName = parameters.getName();
-        this.namePrefix = "";
-        this.fileName = parameters.getFileName();
-        this.isSelf = parameters.isSelf();
+		this.fileName = parameters.getFileName();
 		this.disableFlush = parameters.isDisableFlush();
 		this.disableInfo = parameters.isDisableInfo();
 		this.disableZoom = parameters.isDisableZoom();
@@ -66,21 +62,17 @@ public class Html5SmartImageWidget extends AbstractWidget implements TabbableDia
 		this.tab = parameters.isTab();
 	}
 
-	private String getNamePrefix() {
-		if (StringUtils.isEmpty(originalName) || isSelf) {
-			return "./" + namePrefix;
+	private static String getNameAsPrefix(String name) {
+		if (StringUtils.isEmpty(name)) {
+			return "./";
 		} else {
-			return "./" + namePrefix + originalName + "/";
+			return "./" + name + "/";
 		}
 	}
 
-	private String getFileName() {
-        if (fileName == null) {
-            return "";
-        }
-
-        return fileName;
-    }
+	public String getFileName() {
+		return fileName;
+	}
 
 	public String getTitle() {
 		return title;
@@ -104,35 +96,35 @@ public class Html5SmartImageWidget extends AbstractWidget implements TabbableDia
 
 	public String getCropParameter() {
 		if (!StringUtils.isEmpty(cropParameter)) {
-			return getNamePrefix() + cropParameter;
+			return getNameAsPrefix(originalName) + cropParameter;
 		}
 		return cropParameter;
 	}
 
 	public String getFileNameParameter() {
 		if (!StringUtils.isEmpty(fileNameParameter)) {
-			return getNamePrefix() + fileNameParameter;
+			return getNameAsPrefix(originalName) + fileNameParameter;
 		}
 		return fileNameParameter;
 	}
 
 	public String getFileReferenceParameter() {
 		if (!StringUtils.isEmpty(fileReferenceParameter)) {
-			return getNamePrefix() + fileReferenceParameter;
+			return getNameAsPrefix(originalName) + fileReferenceParameter;
 		}
 		return fileReferenceParameter;
 	}
 
 	public String getMapParameter() {
 		if (!StringUtils.isEmpty(mapParameter)) {
-			return getNamePrefix() + mapParameter;
+			return getNameAsPrefix(originalName) + mapParameter;
 		}
 		return mapParameter;
 	}
 
 	public String getRotateParameter() {
 		if (!StringUtils.isEmpty(rotateParameter)) {
-			return getNamePrefix() + rotateParameter;
+			return getNameAsPrefix(originalName) + rotateParameter;
 		}
 		return rotateParameter;
 	}
@@ -162,19 +154,16 @@ public class Html5SmartImageWidget extends AbstractWidget implements TabbableDia
 	}
 
 	public String getRequestSuffix() {
-		if (StringUtils.isEmpty(originalName) || isSelf) {
-            if (StringUtils.isNotEmpty(namePrefix)) {
-                return "/" + namePrefix + ".img.png";
-            }
+		if (StringUtils.isEmpty(originalName)) {
 			return ".img.png";
 		} else {
-			return "/" + namePrefix + originalName + ".img.png";
+			return "/" + originalName + ".img.png";
 		}
 	}
 
 	@Override
 	public String getName() {
-		return getNamePrefix() + getFileName();
+		return getNameAsPrefix(originalName);
 	}
 
 	@Override
@@ -186,11 +175,6 @@ public class Html5SmartImageWidget extends AbstractWidget implements TabbableDia
 		if (name.endsWith("/")) {
 			newName = newName.substring(0, newName.length() - 1);
 		}
-        if (name.endsWith(originalName)) {
-            namePrefix = newName.substring(0, newName.indexOf(originalName));
-        }
-        else {
-            originalName = newName;
-        }
+		originalName = newName;
 	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidget.java
@@ -25,9 +25,11 @@ import com.citytechinc.cq.component.dialog.TabbableDialogElement;
 @Widget(annotationClass = Html5SmartImage.class, makerClass = Html5SmartImageWidgetMaker.class,
 	xtype = Html5SmartImageWidget.XTYPE)
 public class Html5SmartImageWidget extends AbstractWidget implements TabbableDialogElement {
+
 	public static final String XTYPE = "html5smartimage";
+	public static final String NAME_SUFFIX = "file";
+
 	private String originalName;
-	private final String fileName;
 	private final boolean disableFlush;
 	private final boolean disableInfo;
 	private final boolean disableZoom;
@@ -46,7 +48,6 @@ public class Html5SmartImageWidget extends AbstractWidget implements TabbableDia
 	public Html5SmartImageWidget(Html5SmartImageWidgetParameters parameters) {
 		super(parameters);
 		originalName = parameters.getName();
-		this.fileName = parameters.getFileName();
 		this.disableFlush = parameters.isDisableFlush();
 		this.disableInfo = parameters.isDisableInfo();
 		this.disableZoom = parameters.isDisableZoom();
@@ -63,16 +64,23 @@ public class Html5SmartImageWidget extends AbstractWidget implements TabbableDia
 	}
 
 	private static String getNameAsPrefix(String name) {
-		if (StringUtils.isEmpty(name)) {
-			return "./";
-		} else {
-			return "./" + name + "/";
+		if (!name.endsWith("/")) {
+			return name + "/";
 		}
+        return name;
 	}
 
-	public String getFileName() {
-		return fileName;
-	}
+    private static String getSanitizedName(String name) {
+        String sanitizedName = name;
+        if (sanitizedName.startsWith("./")) {
+            sanitizedName = sanitizedName.substring(2);
+        }
+        if (sanitizedName.endsWith("/")) {
+            sanitizedName = sanitizedName.substring(0, sanitizedName.length() - 1);
+        }
+
+        return sanitizedName;
+    }
 
 	public String getTitle() {
 		return title;
@@ -153,28 +161,28 @@ public class Html5SmartImageWidget extends AbstractWidget implements TabbableDia
 		return height;
 	}
 
+    //NTS: using the oob naming stuff we are adding ./ to the original name --- historically we were not using this which was the purpose of the getasprefix methods.  Now what we need is a sanatize method which removes the ./ if it is there
 	public String getRequestSuffix() {
-		if (StringUtils.isEmpty(originalName)) {
+		if (StringUtils.isEmpty(originalName) || "./".equals(originalName)) {
 			return ".img.png";
-		} else {
-			return "/" + originalName + ".img.png";
+		}
+        else {
+			return "/" + getSanitizedName(originalName) + ".img.png";
 		}
 	}
 
 	@Override
 	public String getName() {
-		return getNameAsPrefix(originalName);
+		return getNameAsPrefix(originalName) + NAME_SUFFIX;
 	}
 
 	@Override
 	public void setName(String name) {
 		String newName = name;
-		if (name.startsWith("./")) {
-			newName = newName.substring(2);
-		}
 		if (name.endsWith("/")) {
 			newName = newName.substring(0, newName.length() - 1);
 		}
 		originalName = newName;
 	}
+
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidgetMaker.java
@@ -34,7 +34,6 @@ public class Html5SmartImageWidgetMaker extends AbstractWidgetMaker<Html5SmartIm
 	public static final String DEFAULT_MAP_PARAMETER = "imageMap";
 	public static final String FILE_REFERENCE_PARAMETER = "fileReference";
 	public static final String FILE_NAME_PARAMETER = "fileName";
-	public static final String FILE_NAME = "file";
 
 	public Html5SmartImageWidgetMaker(WidgetMakerParameters parameters) {
 		super(parameters);
@@ -46,7 +45,6 @@ public class Html5SmartImageWidgetMaker extends AbstractWidgetMaker<Html5SmartIm
 		Html5SmartImage smartImageAnnotation = getAnnotation(Html5SmartImage.class);
 
 		parameters.setName(getNameForField(smartImageAnnotation));
-		parameters.setFileName(FILE_NAME);
 		parameters.setIsSelf(getIsSelfForField(smartImageAnnotation));
 		parameters.setDisableFlush(getDisableFlushForField(smartImageAnnotation));
 		parameters.setDisableInfo(getDisableInfoForField(smartImageAnnotation));
@@ -76,7 +74,10 @@ public class Html5SmartImageWidgetMaker extends AbstractWidgetMaker<Html5SmartIm
 
 	protected String getNameForField(Html5SmartImage smartImageAnnotation) {
 		if (smartImageAnnotation.isSelf()) {
-			return null;
+			if (parameters.isUseDotSlashInName()) {
+				return "./";
+			}
+			return "";
 		} else {
 			return getNameForField();
 		}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidgetMaker.java
@@ -43,7 +43,9 @@ public class Html5SmartImageWidgetMaker extends AbstractWidgetMaker<Html5SmartIm
 
 		Html5SmartImage smartImageAnnotation = getAnnotation(Html5SmartImage.class);
 
-		parameters.setName(getNameForField(smartImageAnnotation));
+		parameters.setName(getNameForField());
+		parameters.setFileName(getFileNameForField(smartImageAnnotation));
+		parameters.setIsSelf(getIsSelfForField(smartImageAnnotation));
 		parameters.setDisableFlush(getDisableFlushForField(smartImageAnnotation));
 		parameters.setDisableInfo(getDisableInfoForField(smartImageAnnotation));
 		parameters.setDisableZoom(getDisableZoomForField(smartImageAnnotation));
@@ -70,15 +72,26 @@ public class Html5SmartImageWidgetMaker extends AbstractWidgetMaker<Html5SmartIm
 
 	}
 
-	protected String getNameForField(Html5SmartImage smartImageAnnotation) {
-		String name = smartImageAnnotation.name();
+    @Override
+    protected String getNameForField() {
+        String originalName = getName();
 
-		if (StringUtils.isNotEmpty(name)) {
-			return name;
-		}
+        if (originalName.startsWith("./")) {
+            return originalName.substring(2);
+        }
 
-		return null;
-	}
+        return originalName;
+    }
+
+    protected String getFileNameForField(Html5SmartImage smartImageAnnotation) {
+        String fileName = smartImageAnnotation.fileName();
+
+        if (StringUtils.isNotEmpty(fileName)) {
+            return fileName;
+        }
+
+        return null;
+    }
 
 	protected String getCropParameterForField(Html5SmartImage smartImageAnnotation) {
 		if (smartImageAnnotation.allowCrop()) {
@@ -141,6 +154,10 @@ public class Html5SmartImageWidgetMaker extends AbstractWidgetMaker<Html5SmartIm
 		}
 
 		return null;
+	}
+
+	protected boolean getIsSelfForField(Html5SmartImage smartImageAnnotation) {
+		return smartImageAnnotation.isSelf();
 	}
 
 	protected boolean getDisableFlushForField(Html5SmartImage smartImageAnnotation) {

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidgetMaker.java
@@ -33,6 +33,8 @@ public class Html5SmartImageWidgetMaker extends AbstractWidgetMaker<Html5SmartIm
 	public static final String DEFAULT_ROTATE_PARAMETER = "imageRotate";
 	public static final String DEFAULT_MAP_PARAMETER = "imageMap";
 	public static final String FILE_REFERENCE_PARAMETER = "fileReference";
+	public static final String FILE_NAME_PARAMETER = "fileName";
+	public static final String FILE_NAME = "file";
 
 	public Html5SmartImageWidgetMaker(WidgetMakerParameters parameters) {
 		super(parameters);
@@ -43,14 +45,14 @@ public class Html5SmartImageWidgetMaker extends AbstractWidgetMaker<Html5SmartIm
 
 		Html5SmartImage smartImageAnnotation = getAnnotation(Html5SmartImage.class);
 
-		parameters.setName(getNameForField());
-		parameters.setFileName(getFileNameForField(smartImageAnnotation));
+		parameters.setName(getNameForField(smartImageAnnotation));
+		parameters.setFileName(FILE_NAME);
 		parameters.setIsSelf(getIsSelfForField(smartImageAnnotation));
 		parameters.setDisableFlush(getDisableFlushForField(smartImageAnnotation));
 		parameters.setDisableInfo(getDisableInfoForField(smartImageAnnotation));
 		parameters.setDisableZoom(getDisableZoomForField(smartImageAnnotation));
 		parameters.setCropParameter(getCropParameterForField(smartImageAnnotation));
-		parameters.setFileNameParameter(getFileNameParameterForField(smartImageAnnotation));
+		parameters.setFileNameParameter(FILE_NAME_PARAMETER);
 		parameters.setFileReferenceParameter(FILE_REFERENCE_PARAMETER);
 		parameters.setMapParameter(getMapParameterForField(smartImageAnnotation));
 		parameters.setRotateParameter(getRotateParameterForField(smartImageAnnotation));
@@ -72,40 +74,17 @@ public class Html5SmartImageWidgetMaker extends AbstractWidgetMaker<Html5SmartIm
 
 	}
 
-    @Override
-    protected String getNameForField() {
-        String originalName = getName();
-
-        if (originalName.startsWith("./")) {
-            return originalName.substring(2);
-        }
-
-        return originalName;
-    }
-
-    protected String getFileNameForField(Html5SmartImage smartImageAnnotation) {
-        String fileName = smartImageAnnotation.fileName();
-
-        if (StringUtils.isNotEmpty(fileName)) {
-            return fileName;
-        }
-
-        return null;
-    }
+	protected String getNameForField(Html5SmartImage smartImageAnnotation) {
+		if (smartImageAnnotation.isSelf()) {
+			return null;
+		} else {
+			return getNameForField();
+		}
+	}
 
 	protected String getCropParameterForField(Html5SmartImage smartImageAnnotation) {
 		if (smartImageAnnotation.allowCrop()) {
 			return DEFAULT_CROP_PARAMETER;
-		}
-
-		return null;
-	}
-
-	protected String getFileNameParameterForField(Html5SmartImage smartImageAnnotation) {
-		String fileNameParameter = smartImageAnnotation.fileNameParameter();
-
-		if (StringUtils.isNotEmpty(fileNameParameter)) {
-			return fileNameParameter;
 		}
 
 		return null;

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidgetParameters.java
@@ -20,7 +20,6 @@ import com.citytechinc.cq.component.util.Constants;
 
 public class Html5SmartImageWidgetParameters extends DefaultWidgetParameters {
 	private String originalName;
-	private String fileName;
 	private boolean isSelf;
 	private boolean disableFlush;
 	private boolean disableInfo;
@@ -43,14 +42,6 @@ public class Html5SmartImageWidgetParameters extends DefaultWidgetParameters {
 	public void setOriginalName(String originalName) {
 		this.originalName = originalName;
 	}
-
-    public String getFileName() {
-        return fileName;
-    }
-
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
-    }
 
     public boolean isSelf() {
         return isSelf;

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/html5smartimage/Html5SmartImageWidgetParameters.java
@@ -20,6 +20,8 @@ import com.citytechinc.cq.component.util.Constants;
 
 public class Html5SmartImageWidgetParameters extends DefaultWidgetParameters {
 	private String originalName;
+	private String fileName;
+	private boolean isSelf;
 	private boolean disableFlush;
 	private boolean disableInfo;
 	private boolean disableZoom;
@@ -42,7 +44,23 @@ public class Html5SmartImageWidgetParameters extends DefaultWidgetParameters {
 		this.originalName = originalName;
 	}
 
-	public boolean isDisableFlush() {
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public boolean isSelf() {
+        return isSelf;
+    }
+
+    public void setIsSelf(boolean isSelf) {
+        this.isSelf = isSelf;
+    }
+
+    public boolean isDisableFlush() {
 		return disableFlush;
 	}
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidget.java
@@ -31,7 +31,6 @@ public class FileUploadWidget extends AbstractTouchUIWidget {
 	private final String text;
 	private final String icon;
 	private final boolean multiple;
-	private final String fileNameParameter;
 	private final String uploadUrl;
 	private final String uploadUrlBuilder;
 	private final Long sizeLimit;
@@ -41,15 +40,14 @@ public class FileUploadWidget extends AbstractTouchUIWidget {
 	// TODO: Event handling ?
 	private final List<String> mimeTypes;
 	private final String filereferenceparameter;
+	private final String fileNameParameter;
 
 	public FileUploadWidget(FileUploadWidgetParameters parameters) {
 		super(parameters);
-
 		title = parameters.getTitle();
 		text = parameters.getText();
 		icon = parameters.getIcon();
 		multiple = parameters.isMultiple();
-		fileNameParameter = parameters.getFileNameParameter();
 		uploadUrl = parameters.getUploadUrl();
 		uploadUrlBuilder = parameters.getUploadUrlBuilder();
 		sizeLimit = parameters.getSizeLimit();
@@ -58,7 +56,7 @@ public class FileUploadWidget extends AbstractTouchUIWidget {
 		dropZone = parameters.getDropZone();
 		mimeTypes = parameters.getMimeTypes();
 		filereferenceparameter = parameters.getFilereferenceparameter();
-
+		fileNameParameter = parameters.getFileNameParameter();
 	}
 
 	@Override
@@ -76,10 +74,6 @@ public class FileUploadWidget extends AbstractTouchUIWidget {
 
 	public boolean isMultiple() {
 		return multiple;
-	}
-
-	public String getFileNameParameter() {
-		return fileNameParameter;
 	}
 
 	public String getUploadUrl() {
@@ -112,5 +106,9 @@ public class FileUploadWidget extends AbstractTouchUIWidget {
 
 	public String getFilereferenceparameter() {
 		return filereferenceparameter;
+	}
+
+	public String getFileNameParameter() {
+		return fileNameParameter;
 	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidget.java
@@ -39,8 +39,6 @@ public class FileUploadWidget extends AbstractTouchUIWidget {
 	private final String dropZone;
 	// TODO: Event handling ?
 	private final List<String> mimeTypes;
-	private final String filereferenceparameter;
-	private final String fileNameParameter;
 
 	public FileUploadWidget(FileUploadWidgetParameters parameters) {
 		super(parameters);
@@ -55,8 +53,6 @@ public class FileUploadWidget extends AbstractTouchUIWidget {
 		useHTML5 = parameters.isUseHTML5();
 		dropZone = parameters.getDropZone();
 		mimeTypes = parameters.getMimeTypes();
-		filereferenceparameter = parameters.getFilereferenceparameter();
-		fileNameParameter = parameters.getFileNameParameter();
 	}
 
 	@Override
@@ -102,13 +98,5 @@ public class FileUploadWidget extends AbstractTouchUIWidget {
 
 	public List<String> getMimeTypes() {
 		return mimeTypes;
-	}
-
-	public String getFilereferenceparameter() {
-		return filereferenceparameter;
-	}
-
-	public String getFileNameParameter() {
-		return fileNameParameter;
 	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidgetMaker.java
@@ -42,7 +42,6 @@ public class FileUploadWidgetMaker extends AbstractTouchUIWidgetMaker<FileUpload
 		widgetParameters.setText(getTextForField(smartFileAnnotation));
 		widgetParameters.setIcon(getIconForField(smartFileAnnotation));
 		widgetParameters.setMultiple(getMultipleForField(smartFileAnnotation));
-		widgetParameters.setFileNameParameter(getFileNameParameterForField(smartFileAnnotation));
 		widgetParameters.setUploadUrl(getUploadUrlForField(smartFileAnnotation));
 		widgetParameters.setUploadUrlBuilder(getUploadUrlBuilderForField(smartFileAnnotation));
 		widgetParameters.setSizeLimit(getSizeLimitForField(smartFileAnnotation));
@@ -50,17 +49,8 @@ public class FileUploadWidgetMaker extends AbstractTouchUIWidgetMaker<FileUpload
 		widgetParameters.setUseHTML5(getUseHTML5ForField(smartFileAnnotation));
 		widgetParameters.setDropZone(getDropZoneForField(smartFileAnnotation));
 		widgetParameters.setMimeTypes(getMimeTypesForField(smartFileAnnotation));
-		widgetParameters.setFilereferenceparameter(getFileReferenceForField(smartFileAnnotation));
 
 		return new FileUploadWidget(widgetParameters);
-	}
-
-	private String getFileReferenceForField(Html5SmartFile annotation) {
-		if (annotation != null && StringUtils.isNotBlank(annotation.fileReferenceParameter())) {
-			return annotation.fileReferenceParameter();
-		}
-
-		return null;
 	}
 
 	public String getTitleForField(Html5SmartFile annotation) {

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidgetParameters.java
@@ -25,7 +25,6 @@ public class FileUploadWidgetParameters extends DefaultTouchUIWidgetParameters {
 	private String text;
 	private String icon;
 	private boolean multiple;
-	private String fileNameParameter;
 	private String uploadUrl;
 	private String uploadUrlBuilder;
 	private Long sizeLimit;
@@ -34,7 +33,6 @@ public class FileUploadWidgetParameters extends DefaultTouchUIWidgetParameters {
 	private String dropZone;
 	// TODO: Event handling
 	private List<String> mimeTypes;
-	private String filereferenceparameter;
 
 	@Override
 	public String getTitle() {
@@ -68,14 +66,6 @@ public class FileUploadWidgetParameters extends DefaultTouchUIWidgetParameters {
 
 	public void setMultiple(boolean multiple) {
 		this.multiple = multiple;
-	}
-
-	public String getFileNameParameter() {
-		return fileNameParameter;
-	}
-
-	public void setFileNameParameter(String fileNameParameter) {
-		this.fileNameParameter = fileNameParameter;
 	}
 
 	public String getUploadUrl() {
@@ -142,14 +132,6 @@ public class FileUploadWidgetParameters extends DefaultTouchUIWidgetParameters {
 	@Override
 	public void setResourceType(String resourceType) {
 		throw new UnsupportedOperationException("resourceType is Static for FileUploadWidget");
-	}
-
-	public String getFilereferenceparameter() {
-		return filereferenceparameter;
-	}
-
-	public void setFilereferenceparameter(String filereferenceparameter) {
-		this.filereferenceparameter = filereferenceparameter;
 	}
 
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidget.java
@@ -18,14 +18,59 @@ package com.citytechinc.cq.component.touchuidialog.widget.smartimage;
 import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
 import com.citytechinc.cq.component.annotations.widgets.Html5SmartImage;
 import com.citytechinc.cq.component.touchuidialog.widget.fileupload.FileUploadWidget;
-import com.citytechinc.cq.component.touchuidialog.widget.fileupload.FileUploadWidgetParameters;
+import org.codehaus.plexus.util.StringUtils;
 
 @TouchUIWidget(annotationClass = Html5SmartImage.class, makerClass = SmartImageWidgetMaker.class,
 	resourceType = FileUploadWidget.RESOURCE_TYPE)
 public class SmartImageWidget extends FileUploadWidget {
 
-	public SmartImageWidget(FileUploadWidgetParameters parameters) {
+    private final boolean isSelf;
+    private final String originalName;
+    private final String fileName;
+
+	public SmartImageWidget(SmartImageWidgetParameters parameters) {
 		super(parameters);
+
+        originalName = parameters.getName();
+        fileName = parameters.getFileName();
+        isSelf = parameters.isSelf();
 	}
+
+	@Override
+	public String getName() {
+		return getNamePrefix() + getFileName();
+	}
+
+    @Override
+    public String getFileNameParameter() {
+        if (!StringUtils.isEmpty(super.getFileNameParameter())) {
+            return getNamePrefix() + super.getFileNameParameter();
+        }
+        return super.getFileNameParameter();
+    }
+
+    @Override
+    public String getFilereferenceparameter() {
+        if (!StringUtils.isEmpty(super.getFilereferenceparameter())) {
+            return getNamePrefix() + super.getFilereferenceparameter();
+        }
+        return super.getFilereferenceparameter();
+    }
+
+    private String getFileName() {
+        if (fileName != null) {
+            return fileName;
+        }
+
+        return "";
+    }
+
+    private String getNamePrefix() {
+        if (StringUtils.isEmpty(originalName) || isSelf) {
+            return "./";
+        } else {
+            return "./" + originalName + "/";
+        }
+    }
 
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidget.java
@@ -17,6 +17,7 @@ package com.citytechinc.cq.component.touchuidialog.widget.smartimage;
 
 import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
 import com.citytechinc.cq.component.annotations.widgets.Html5SmartImage;
+import com.citytechinc.cq.component.dialog.html5smartimage.Html5SmartImageWidget;
 import com.citytechinc.cq.component.touchuidialog.widget.fileupload.FileUploadWidget;
 
 @TouchUIWidget(annotationClass = Html5SmartImage.class, makerClass = SmartImageWidgetMaker.class,
@@ -27,4 +28,25 @@ public class SmartImageWidget extends FileUploadWidget {
 		super(parameters);
 	}
 
+    private static String getNameAsPrefix(String name) {
+        if (!name.endsWith("/")) {
+            return name + "/";
+        }
+        return name;
+    }
+
+    @Override
+	public String getName() {
+        return getNameAsPrefix(super.getName()) + Html5SmartImageWidget.NAME_SUFFIX;
+    }
+
+    @Override
+    public String getFilereferenceparameter() {
+        return getNameAsPrefix(super.getName()) + super.getFilereferenceparameter();
+    }
+
+    @Override
+    public String getFileNameParameter() {
+        return getNameAsPrefix(super.getName()) + super.getFileNameParameter();
+    }
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidget.java
@@ -17,7 +17,6 @@ package com.citytechinc.cq.component.touchuidialog.widget.smartimage;
 
 import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
 import com.citytechinc.cq.component.annotations.widgets.Html5SmartImage;
-import com.citytechinc.cq.component.dialog.html5smartimage.Html5SmartImageWidget;
 import com.citytechinc.cq.component.touchuidialog.widget.fileupload.FileUploadWidget;
 
 @TouchUIWidget(annotationClass = Html5SmartImage.class, makerClass = SmartImageWidgetMaker.class,
@@ -28,25 +27,4 @@ public class SmartImageWidget extends FileUploadWidget {
 		super(parameters);
 	}
 
-    private static String getNameAsPrefix(String name) {
-        if (!name.endsWith("/")) {
-            return name + "/";
-        }
-        return name;
-    }
-
-    @Override
-	public String getName() {
-        return getNameAsPrefix(super.getName()) + Html5SmartImageWidget.NAME_SUFFIX;
-    }
-
-    @Override
-    public String getFilereferenceparameter() {
-        return getNameAsPrefix(super.getName()) + super.getFilereferenceparameter();
-    }
-
-    @Override
-    public String getFileNameParameter() {
-        return getNameAsPrefix(super.getName()) + super.getFileNameParameter();
-    }
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidget.java
@@ -18,59 +18,13 @@ package com.citytechinc.cq.component.touchuidialog.widget.smartimage;
 import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
 import com.citytechinc.cq.component.annotations.widgets.Html5SmartImage;
 import com.citytechinc.cq.component.touchuidialog.widget.fileupload.FileUploadWidget;
-import org.codehaus.plexus.util.StringUtils;
 
 @TouchUIWidget(annotationClass = Html5SmartImage.class, makerClass = SmartImageWidgetMaker.class,
 	resourceType = FileUploadWidget.RESOURCE_TYPE)
 public class SmartImageWidget extends FileUploadWidget {
 
-    private final boolean isSelf;
-    private final String originalName;
-    private final String fileName;
-
 	public SmartImageWidget(SmartImageWidgetParameters parameters) {
 		super(parameters);
-
-        originalName = parameters.getName();
-        fileName = parameters.getFileName();
-        isSelf = parameters.isSelf();
 	}
-
-	@Override
-	public String getName() {
-		return getNamePrefix() + getFileName();
-	}
-
-    @Override
-    public String getFileNameParameter() {
-        if (!StringUtils.isEmpty(super.getFileNameParameter())) {
-            return getNamePrefix() + super.getFileNameParameter();
-        }
-        return super.getFileNameParameter();
-    }
-
-    @Override
-    public String getFilereferenceparameter() {
-        if (!StringUtils.isEmpty(super.getFilereferenceparameter())) {
-            return getNamePrefix() + super.getFilereferenceparameter();
-        }
-        return super.getFilereferenceparameter();
-    }
-
-    private String getFileName() {
-        if (fileName != null) {
-            return fileName;
-        }
-
-        return "";
-    }
-
-    private String getNamePrefix() {
-        if (StringUtils.isEmpty(originalName) || isSelf) {
-            return "./";
-        } else {
-            return "./" + originalName + "/";
-        }
-    }
 
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidgetMaker.java
@@ -30,11 +30,9 @@ import com.citytechinc.cq.component.touchuidialog.widget.maker.TouchUIWidgetMake
 
 public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<SmartImageWidgetParameters> {
 	private static final String[] MIME_TYPES = { "image" };
-	private final TouchUIWidgetMakerParameters parameters;
 
 	public SmartImageWidgetMaker(TouchUIWidgetMakerParameters parameters) {
 		super(parameters);
-		this.parameters = parameters;
 	}
 
 	@Override
@@ -45,46 +43,28 @@ public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<SmartImage
 			.warn(
 				"There is no HTML5 Smart Image analog in the Touch UI. This field is being rendered as a fileupload however this is most likely not what you want. Use the image inline editor instead for this field.");
 
-		Html5SmartImage smartFileAnnotation = getAnnotation(Html5SmartImage.class);
+		Html5SmartImage smartImageAnnotation = getAnnotation(Html5SmartImage.class);
 
-        widgetParameters.setName(getNameForField());
-        widgetParameters.setFileName(getFileNameForField(smartFileAnnotation));
-		widgetParameters.setTitle(getTitleForField(smartFileAnnotation));
-		widgetParameters.setText(getTextForField(smartFileAnnotation));
-		widgetParameters.setIcon(getIconForField(smartFileAnnotation));
-		widgetParameters.setMultiple(getMultipleForField(smartFileAnnotation));
-		widgetParameters.setFileNameParameter(getFileNameParameterForField(smartFileAnnotation));
-		widgetParameters.setUploadUrl(getUploadUrlForField(smartFileAnnotation));
-		widgetParameters.setUploadUrlBuilder(getUploadUrlBuilderForField(smartFileAnnotation));
-		widgetParameters.setSizeLimit(getSizeLimitForField(smartFileAnnotation));
-		widgetParameters.setAutoStart(getAutoStartForField(smartFileAnnotation));
-		widgetParameters.setUseHTML5(getUseHTML5ForField(smartFileAnnotation));
-		widgetParameters.setDropZone(getDropZoneForField(smartFileAnnotation));
+		widgetParameters.setName(getNameForField());
+		widgetParameters.setFileName(Html5SmartImageWidgetMaker.FILE_NAME);
+		widgetParameters.setTitle(getTitleForField(smartImageAnnotation));
+		widgetParameters.setText(getTextForField(smartImageAnnotation));
+		widgetParameters.setIcon(getIconForField(smartImageAnnotation));
+		widgetParameters.setMultiple(getMultipleForField(smartImageAnnotation));
+		widgetParameters.setFileNameParameter(getNameAsPrefix(smartImageAnnotation)
+			+ Html5SmartImageWidgetMaker.FILE_NAME_PARAMETER);
+		widgetParameters.setUploadUrl(getUploadUrlForField(smartImageAnnotation));
+		widgetParameters.setUploadUrlBuilder(getUploadUrlBuilderForField(smartImageAnnotation));
+		widgetParameters.setSizeLimit(getSizeLimitForField(smartImageAnnotation));
+		widgetParameters.setAutoStart(getAutoStartForField(smartImageAnnotation));
+		widgetParameters.setUseHTML5(getUseHTML5ForField(smartImageAnnotation));
+		widgetParameters.setDropZone(getDropZoneForField(smartImageAnnotation));
 		widgetParameters.setMimeTypes(Arrays.asList(MIME_TYPES));
-		widgetParameters.setFilereferenceparameter(Html5SmartImageWidgetMaker.FILE_REFERENCE_PARAMETER);
+		widgetParameters.setFilereferenceparameter(getNameAsPrefix(smartImageAnnotation)
+			+ Html5SmartImageWidgetMaker.FILE_REFERENCE_PARAMETER);
 
 		return new SmartImageWidget(widgetParameters);
 	}
-
-    @Override
-    protected String getNameForField() {
-        String originalName = getName();
-
-        if (originalName.startsWith("./")) {
-            return originalName.substring(2);
-        }
-
-        return originalName;
-    }
-
-
-    public String getFileNameForField(Html5SmartImage annotation) {
-        if (annotation != null & StringUtils.isNotBlank(annotation.fileName())) {
-            return annotation.fileName();
-        }
-
-        return null;
-    }
 
 	public String getTitleForField(Html5SmartImage annotation) {
 		if (annotation != null && StringUtils.isNotBlank(annotation.title())) {
@@ -116,14 +96,6 @@ public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<SmartImage
 		}
 
 		return false;
-	}
-
-	public String getFileNameParameterForField(Html5SmartImage annotation) {
-		if (annotation != null && StringUtils.isNotBlank(annotation.fileNameParameter())) {
-			return annotation.fileNameParameter();
-		}
-
-		return null;
 	}
 
 	public String getUploadUrlForField(Html5SmartImage annotation) {
@@ -174,4 +146,14 @@ public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<SmartImage
 		return null;
 	}
 
+	private String getNameAsPrefix(Html5SmartImage annotation) {
+		StringBuilder sb = new StringBuilder();
+		if (parameters.isUseDotSlashInName()) {
+			sb.append("./");
+		}
+		if (StringUtils.isNotEmpty(getName()) && !annotation.isSelf()) {
+			sb.append(getName()).append("/");
+		}
+		return sb.toString();
+	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidgetMaker.java
@@ -21,7 +21,7 @@ import org.codehaus.plexus.util.StringUtils;
 
 import com.citytechinc.cq.component.annotations.widgets.Html5SmartImage;
 import com.citytechinc.cq.component.dialog.exception.InvalidComponentFieldException;
-import com.citytechinc.cq.component.dialog.html5smartimage.Html5SmartImageWidgetMaker;
+import com.citytechinc.cq.component.dialog.html5smartimage.Html5SmartImageWidget;
 import com.citytechinc.cq.component.maven.util.LogSingleton;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
 import com.citytechinc.cq.component.touchuidialog.exceptions.TouchUIDialogGenerationException;
@@ -45,12 +45,11 @@ public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<SmartImage
 
 		Html5SmartImage smartImageAnnotation = getAnnotation(Html5SmartImage.class);
 
-		widgetParameters.setName(getNameForField(smartImageAnnotation));
+		widgetParameters.setName(getNameAsPrefix(smartImageAnnotation) + Html5SmartImageWidget.NAME_SUFFIX);
 		widgetParameters.setTitle(getTitleForField(smartImageAnnotation));
 		widgetParameters.setText(getTextForField(smartImageAnnotation));
 		widgetParameters.setIcon(getIconForField(smartImageAnnotation));
 		widgetParameters.setMultiple(getMultipleForField(smartImageAnnotation));
-		widgetParameters.setFileNameParameter(Html5SmartImageWidgetMaker.FILE_NAME_PARAMETER);
 		widgetParameters.setUploadUrl(getUploadUrlForField(smartImageAnnotation));
 		widgetParameters.setUploadUrlBuilder(getUploadUrlBuilderForField(smartImageAnnotation));
 		widgetParameters.setSizeLimit(getSizeLimitForField(smartImageAnnotation));
@@ -58,21 +57,9 @@ public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<SmartImage
 		widgetParameters.setUseHTML5(getUseHTML5ForField(smartImageAnnotation));
 		widgetParameters.setDropZone(getDropZoneForField(smartImageAnnotation));
 		widgetParameters.setMimeTypes(Arrays.asList(MIME_TYPES));
-		widgetParameters.setFilereferenceparameter(Html5SmartImageWidgetMaker.FILE_REFERENCE_PARAMETER);
 
 		return new SmartImageWidget(widgetParameters);
 	}
-
-    public String getNameForField(Html5SmartImage annotation) {
-        if (annotation.isSelf()) {
-            if (parameters.isUseDotSlashInName()) {
-                return "./";
-            }
-            return "";
-        } else {
-            return getNameForField();
-        }
-    }
 
 	public String getTitleForField(Html5SmartImage annotation) {
 		if (annotation != null && StringUtils.isNotBlank(annotation.title())) {
@@ -152,5 +139,16 @@ public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<SmartImage
 		}
 
 		return null;
+	}
+
+	private String getNameAsPrefix(Html5SmartImage annotation) {
+		StringBuilder sb = new StringBuilder();
+		if (parameters.isUseDotSlashInName()) {
+			sb.append("./");
+		}
+		if (StringUtils.isNotEmpty(getName()) && !annotation.isSelf()) {
+			sb.append(getName()).append("/");
+		}
+		return sb.toString();
 	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidgetMaker.java
@@ -45,14 +45,12 @@ public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<SmartImage
 
 		Html5SmartImage smartImageAnnotation = getAnnotation(Html5SmartImage.class);
 
-		widgetParameters.setName(getNameForField());
-		widgetParameters.setFileName(Html5SmartImageWidgetMaker.FILE_NAME);
+		widgetParameters.setName(getNameForField(smartImageAnnotation));
 		widgetParameters.setTitle(getTitleForField(smartImageAnnotation));
 		widgetParameters.setText(getTextForField(smartImageAnnotation));
 		widgetParameters.setIcon(getIconForField(smartImageAnnotation));
 		widgetParameters.setMultiple(getMultipleForField(smartImageAnnotation));
-		widgetParameters.setFileNameParameter(getNameAsPrefix(smartImageAnnotation)
-			+ Html5SmartImageWidgetMaker.FILE_NAME_PARAMETER);
+		widgetParameters.setFileNameParameter(Html5SmartImageWidgetMaker.FILE_NAME_PARAMETER);
 		widgetParameters.setUploadUrl(getUploadUrlForField(smartImageAnnotation));
 		widgetParameters.setUploadUrlBuilder(getUploadUrlBuilderForField(smartImageAnnotation));
 		widgetParameters.setSizeLimit(getSizeLimitForField(smartImageAnnotation));
@@ -60,11 +58,21 @@ public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<SmartImage
 		widgetParameters.setUseHTML5(getUseHTML5ForField(smartImageAnnotation));
 		widgetParameters.setDropZone(getDropZoneForField(smartImageAnnotation));
 		widgetParameters.setMimeTypes(Arrays.asList(MIME_TYPES));
-		widgetParameters.setFilereferenceparameter(getNameAsPrefix(smartImageAnnotation)
-			+ Html5SmartImageWidgetMaker.FILE_REFERENCE_PARAMETER);
+		widgetParameters.setFilereferenceparameter(Html5SmartImageWidgetMaker.FILE_REFERENCE_PARAMETER);
 
 		return new SmartImageWidget(widgetParameters);
 	}
+
+    public String getNameForField(Html5SmartImage annotation) {
+        if (annotation.isSelf()) {
+            if (parameters.isUseDotSlashInName()) {
+                return "./";
+            }
+            return "";
+        } else {
+            return getNameForField();
+        }
+    }
 
 	public String getTitleForField(Html5SmartImage annotation) {
 		if (annotation != null && StringUtils.isNotBlank(annotation.title())) {
@@ -144,16 +152,5 @@ public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<SmartImage
 		}
 
 		return null;
-	}
-
-	private String getNameAsPrefix(Html5SmartImage annotation) {
-		StringBuilder sb = new StringBuilder();
-		if (parameters.isUseDotSlashInName()) {
-			sb.append("./");
-		}
-		if (StringUtils.isNotEmpty(getName()) && !annotation.isSelf()) {
-			sb.append(getName()).append("/");
-		}
-		return sb.toString();
 	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidgetMaker.java
@@ -25,11 +25,10 @@ import com.citytechinc.cq.component.dialog.html5smartimage.Html5SmartImageWidget
 import com.citytechinc.cq.component.maven.util.LogSingleton;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
 import com.citytechinc.cq.component.touchuidialog.exceptions.TouchUIDialogGenerationException;
-import com.citytechinc.cq.component.touchuidialog.widget.fileupload.FileUploadWidgetParameters;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.AbstractTouchUIWidgetMaker;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.TouchUIWidgetMakerParameters;
 
-public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<FileUploadWidgetParameters> {
+public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<SmartImageWidgetParameters> {
 	private static final String[] MIME_TYPES = { "image" };
 	private final TouchUIWidgetMakerParameters parameters;
 
@@ -39,7 +38,7 @@ public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<FileUpload
 	}
 
 	@Override
-	public TouchUIDialogElement make(FileUploadWidgetParameters widgetParameters) throws ClassNotFoundException,
+	public TouchUIDialogElement make(SmartImageWidgetParameters widgetParameters) throws ClassNotFoundException,
 		InvalidComponentFieldException, TouchUIDialogGenerationException {
 		LogSingleton
 			.getInstance()
@@ -48,6 +47,8 @@ public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<FileUpload
 
 		Html5SmartImage smartFileAnnotation = getAnnotation(Html5SmartImage.class);
 
+        widgetParameters.setName(getNameForField());
+        widgetParameters.setFileName(getFileNameForField(smartFileAnnotation));
 		widgetParameters.setTitle(getTitleForField(smartFileAnnotation));
 		widgetParameters.setText(getTextForField(smartFileAnnotation));
 		widgetParameters.setIcon(getIconForField(smartFileAnnotation));
@@ -60,11 +61,30 @@ public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<FileUpload
 		widgetParameters.setUseHTML5(getUseHTML5ForField(smartFileAnnotation));
 		widgetParameters.setDropZone(getDropZoneForField(smartFileAnnotation));
 		widgetParameters.setMimeTypes(Arrays.asList(MIME_TYPES));
-		widgetParameters.setFilereferenceparameter(getNameAsPrefix(smartFileAnnotation)
-			+ Html5SmartImageWidgetMaker.FILE_REFERENCE_PARAMETER);
+		widgetParameters.setFilereferenceparameter(Html5SmartImageWidgetMaker.FILE_REFERENCE_PARAMETER);
 
 		return new SmartImageWidget(widgetParameters);
 	}
+
+    @Override
+    protected String getNameForField() {
+        String originalName = getName();
+
+        if (originalName.startsWith("./")) {
+            return originalName.substring(2);
+        }
+
+        return originalName;
+    }
+
+
+    public String getFileNameForField(Html5SmartImage annotation) {
+        if (annotation != null & StringUtils.isNotBlank(annotation.fileName())) {
+            return annotation.fileName();
+        }
+
+        return null;
+    }
 
 	public String getTitleForField(Html5SmartImage annotation) {
 		if (annotation != null && StringUtils.isNotBlank(annotation.title())) {
@@ -152,17 +172,6 @@ public class SmartImageWidgetMaker extends AbstractTouchUIWidgetMaker<FileUpload
 		}
 
 		return null;
-	}
-
-	private String getNameAsPrefix(Html5SmartImage annotation) {
-		StringBuilder sb = new StringBuilder();
-		if (parameters.isUseDotSlashInName()) {
-			sb.append("./");
-		}
-		if (StringUtils.isNotEmpty(annotation.name())) {
-			sb.append(annotation.name()).append("/");
-		}
-		return sb.toString();
 	}
 
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidgetParameters.java
@@ -19,16 +19,7 @@ import com.citytechinc.cq.component.touchuidialog.widget.fileupload.FileUploadWi
 
 public class SmartImageWidgetParameters extends FileUploadWidgetParameters {
 
-    private String fileName;
     private boolean isSelf;
-
-    public String getFileName() {
-        return fileName;
-    }
-
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
-    }
 
     public boolean isSelf() {
         return isSelf;

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/smartimage/SmartImageWidgetParameters.java
@@ -1,0 +1,40 @@
+/**
+ *    Copyright 2013 CITYTECH, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.smartimage;
+
+import com.citytechinc.cq.component.touchuidialog.widget.fileupload.FileUploadWidgetParameters;
+
+public class SmartImageWidgetParameters extends FileUploadWidgetParameters {
+
+    private String fileName;
+    private boolean isSelf;
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public boolean isSelf() {
+        return isSelf;
+    }
+
+    public void setIsSelf(boolean isSelf) {
+        this.isSelf = isSelf;
+    }
+}


### PR DESCRIPTION
Submitted for your consideration --- 

I've made updates to support / enforce the resource structure which the OOB Image / DownloadResource classes expect when using the Html5SmartImage annotation for both Touch and Classic UI.  This, coupled with supporting updates in bedrock, give us the ability to do 

```
@DialogField(tab = 2)
@Html5SmartImage
@ImageInject @Optional
Image myImage
```

and have it work as expected.  The above will create a situation where the image is stored in a child resource named "myImage".  This will be where fileReference, fileName, and other image related properties are stored as well.  In the case where a user uploads a file directly via the widget it will be stored in a child of the "myImage" resource named "file," which is the name that DownloadResource is expecting to find when looking for image file content. 