### PR TITLE
Addition of extraClientlibs property to @Component annotation

### DIFF
--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/Component.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/Component.java
@@ -15,14 +15,14 @@
  */
 package com.citytechinc.cq.component.annotations;
 
+import com.citytechinc.cq.component.annotations.editconfig.ActionConfig;
+import com.citytechinc.cq.component.annotations.editconfig.DropTarget;
+import com.citytechinc.cq.component.annotations.editconfig.FormParameter;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import com.citytechinc.cq.component.annotations.editconfig.ActionConfig;
-import com.citytechinc.cq.component.annotations.editconfig.DropTarget;
-import com.citytechinc.cq.component.annotations.editconfig.FormParameter;
 
 /**
  * The Component annotation is used to indicate that a Class represents a CQ
@@ -350,6 +350,13 @@ public @interface Component {
 	 * @return ContentProperty[]
 	 */
 	ContentProperty[] contentAdditionalProperties() default {};
+
+	/**
+	 * A list of extra client libs to be included on the jcr:root node
+	 *
+	 * @return ComponentProperty[]
+	 */
+	String[] extraClientlibs() default {};
 
 	/**
 	 * Indicates whether the Target context menu should be disabled for the

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/Dialog.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/Dialog.java
@@ -15,14 +15,14 @@
  */
 package com.citytechinc.cq.component.dialog;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import com.citytechinc.cq.component.dialog.tabpanel.TabPanel;
 import com.citytechinc.cq.component.dialog.tabpanel.TabPanelParameters;
 import com.citytechinc.cq.component.dialog.widgetcollection.WidgetCollection;
 import com.citytechinc.cq.component.dialog.widgetcollection.WidgetCollectionParameters;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class Dialog extends AbstractWidget {
 	private final String title;

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/TouchUIDialog.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/TouchUIDialog.java
@@ -26,6 +26,7 @@ public class TouchUIDialog extends AbstractTouchUIDialogElement {
 	private String fileName;
 	private NameSpacedAttribute<String> title;
 	private String helpPath;
+	private String[] extraClientlibs;
 
 	public TouchUIDialog(TouchUIDialogParameters parameters) {
 		super(parameters);
@@ -34,6 +35,7 @@ public class TouchUIDialog extends AbstractTouchUIDialogElement {
 		this.title =
 			new NameSpacedAttribute<String>(Constants.JCR_NS_URI, Constants.JCR_NS_PREFIX, parameters.getTitle());
 		this.helpPath = parameters.getHelpPath();
+		this.extraClientlibs = parameters.getExtraClientlibs();
 	}
 
 	public String getFileName() {
@@ -50,6 +52,10 @@ public class TouchUIDialog extends AbstractTouchUIDialogElement {
 
 	public String getMode() {
 		return "edit";
+	}
+
+	public String[] getExtraClientlibs() {
+		return extraClientlibs;
 	}
 
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/TouchUIDialogParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/TouchUIDialogParameters.java
@@ -25,6 +25,7 @@ public class TouchUIDialogParameters extends DefaultTouchUIDialogElementParamete
 	private String fileName;
 	private String title;
 	private String helpPath;
+	private String[] extraClientlibs;
 
 	@Override
 	public String getResourceType() {
@@ -72,5 +73,11 @@ public class TouchUIDialogParameters extends DefaultTouchUIDialogElementParamete
 
 	public void setHelpPath(String helpPath) {
 		this.helpPath = helpPath;
+	}
+
+	public void setExtraClientlibs(String[] extraClientlibs) { this.extraClientlibs = extraClientlibs; }
+
+	public String[] getExtraClientlibs() {
+		return extraClientlibs;
 	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/factory/TouchUIDialogFactory.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/factory/TouchUIDialogFactory.java
@@ -15,16 +15,6 @@
  */
 package com.citytechinc.cq.component.touchuidialog.factory;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javassist.ClassPool;
-import javassist.CtClass;
-
-import javax.annotation.Nullable;
-
-import org.codehaus.plexus.util.StringUtils;
-
 import com.citytechinc.cq.component.annotations.Component;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialog;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogParameters;
@@ -36,6 +26,13 @@ import com.citytechinc.cq.component.touchuidialog.layout.maker.exceptions.Layout
 import com.citytechinc.cq.component.touchuidialog.layout.tabs.TabsLayoutMaker;
 import com.citytechinc.cq.component.touchuidialog.widget.registry.TouchUIWidgetRegistry;
 import com.citytechinc.cq.component.xml.XmlElement;
+import javassist.ClassPool;
+import javassist.CtClass;
+import org.codehaus.plexus.util.StringUtils;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 
 public class TouchUIDialogFactory {
 
@@ -81,6 +78,12 @@ public class TouchUIDialogFactory {
 			containedElements.add(layout);
 
 			parameters.setContainedElements(containedElements);
+
+			// Add the extraClientLibs parameter
+			String[] extraClientlibs = componentAnnotation.extraClientlibs();
+			if(extraClientlibs.length > 0){
+				parameters.setExtraClientlibs(componentAnnotation.extraClientlibs());
+			}
 
 			return new TouchUIDialog(parameters);
 


### PR DESCRIPTION
Addition of extraClientlibs property to @Component annotation for touch dialogs only. Accepts a list of client lib categories, and spits them out on the jcr:root node of the generated touch dialog. 

