### PR TITLE
TouchUI Checkbox Annotation Fixes

### DIFF
--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/CheckBox.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/CheckBox.java
@@ -50,13 +50,16 @@ public @interface CheckBox {
 	boolean checked() default false;
 	
 	/**
-	 * Used for Touch UI only
+	 * Used for Touch UI Only
 	 * 
-	 * The value to be stored if the checkbox is checked.
+	 * Indicates if the checkbox is checked. This will emply ignoreData to be true.
+	 * To set this to be true or false add a boolean with the desired value. To not
+	 * set this at all (and thereby cause ignoreData to remain false) dont set this
+	 * field, or suppy an empoty array.
 	 *
 	 * @return boolean
 	 */
-	String value() default "{Boolean}true";
+	boolean[] touchUIChecked() default {};
 
 	/**
 	 * Used for Touch UI only

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/CheckBox.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/CheckBox.java
@@ -41,11 +41,22 @@ public @interface CheckBox {
 	String inputValue() default "on";
 
 	/**
-	 * true if the checkbox should render initially checked
+	 * Used for Classis UI only
+	 * 
+	 * True if the checkbox should render initially checked
 	 *
 	 * @return boolean
 	 */
 	boolean checked() default false;
+	
+	/**
+	 * Used for Touch UI only
+	 * 
+	 * The value to be stored if the checkbox is checked.
+	 *
+	 * @return boolean
+	 */
+	String value() default "{Boolean}true";
 
 	/**
 	 * Used for Touch UI only

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidget.java
@@ -27,14 +27,14 @@ public class CheckboxWidget extends AbstractTouchUIWidget {
 
 	private final String text;
 	private final String title;
-	private final String value;
+	private final boolean[] checked;
 
 	public CheckboxWidget(CheckboxWidgetParameters parameters) {
 		super(parameters);
 
 		text = parameters.getText();
 		title = parameters.getTitle();
-		value = parameters.getValue();
+		checked = parameters.getChecked();
 
 	}
 
@@ -46,8 +46,11 @@ public class CheckboxWidget extends AbstractTouchUIWidget {
 		return title;
 	}
 
-	public String getValue() {
-		return value;
+	public Boolean getChecked() {
+		if (checked != null && checked.length != 0) {
+			return new Boolean(checked[0]);
+		} else {
+			return null;
+		}
 	}
-
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidget.java
@@ -27,14 +27,14 @@ public class CheckboxWidget extends AbstractTouchUIWidget {
 
 	private final String text;
 	private final String title;
-	private final boolean checked;
+	private final String value;
 
 	public CheckboxWidget(CheckboxWidgetParameters parameters) {
 		super(parameters);
 
 		text = parameters.getText();
 		title = parameters.getTitle();
-		checked = parameters.isChecked();
+		value = parameters.getValue();
 
 	}
 
@@ -46,8 +46,8 @@ public class CheckboxWidget extends AbstractTouchUIWidget {
 		return title;
 	}
 
-	public boolean isChecked() {
-		return checked;
+	public String getValue() {
+		return value;
 	}
 
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidgetMaker.java
@@ -38,7 +38,7 @@ public class CheckboxWidgetMaker extends AbstractTouchUIWidgetMaker<CheckboxWidg
 
 		widgetParameters.setText(getTextForField(checkboxAnnotation));
 		widgetParameters.setTitle(getTitleForField(checkboxAnnotation));
-		widgetParameters.setValue(getValueForField(checkboxAnnotation));
+		widgetParameters.setChecked(getCheckedForField(checkboxAnnotation));
 
 		return new CheckboxWidget(widgetParameters);
 	}
@@ -59,12 +59,12 @@ public class CheckboxWidgetMaker extends AbstractTouchUIWidgetMaker<CheckboxWidg
 		return null;
 	}
 	
-	public String getValueForField(CheckBox annotation) {
-		if (annotation != null && StringUtils.isNotBlank(annotation.value())) {
-			return annotation.value();
+	public boolean[] getCheckedForField(CheckBox annotation) {
+		if (annotation != null) {
+			return annotation.touchUIChecked();
 		}
 
-		return null;
+		return new boolean[0];
 	}
 
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidgetMaker.java
@@ -38,7 +38,7 @@ public class CheckboxWidgetMaker extends AbstractTouchUIWidgetMaker<CheckboxWidg
 
 		widgetParameters.setText(getTextForField(checkboxAnnotation));
 		widgetParameters.setTitle(getTitleForField(checkboxAnnotation));
-		widgetParameters.setChecked(getCheckedForField(checkboxAnnotation));
+		widgetParameters.setValue(getValueForField(checkboxAnnotation));
 
 		return new CheckboxWidget(widgetParameters);
 	}
@@ -58,13 +58,13 @@ public class CheckboxWidgetMaker extends AbstractTouchUIWidgetMaker<CheckboxWidg
 
 		return null;
 	}
-
-	public boolean getCheckedForField(CheckBox annotation) {
-		if (annotation != null) {
-			return annotation.checked();
+	
+	public String getValueForField(CheckBox annotation) {
+		if (annotation != null && StringUtils.isNotBlank(annotation.value())) {
+			return annotation.value();
 		}
 
-		return false;
+		return null;
 	}
 
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidgetParameters.java
@@ -21,7 +21,7 @@ public class CheckboxWidgetParameters extends DefaultTouchUIWidgetParameters {
 
 	private String text;
 	private String title;
-	private boolean checked;
+	private String value;
 
 	public String getText() {
 		return text;
@@ -29,6 +29,14 @@ public class CheckboxWidgetParameters extends DefaultTouchUIWidgetParameters {
 
 	public void setText(String text) {
 		this.text = text;
+	}
+	
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
 	}
 
 	@Override
@@ -39,14 +47,6 @@ public class CheckboxWidgetParameters extends DefaultTouchUIWidgetParameters {
 	@Override
 	public void setTitle(String title) {
 		this.title = title;
-	}
-
-	public boolean isChecked() {
-		return checked;
-	}
-
-	public void setChecked(boolean checked) {
-		this.checked = checked;
 	}
 
 	@Override

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidgetParameters.java
@@ -21,7 +21,7 @@ public class CheckboxWidgetParameters extends DefaultTouchUIWidgetParameters {
 
 	private String text;
 	private String title;
-	private String value;
+	private boolean[] checked;
 
 	public String getText() {
 		return text;
@@ -31,12 +31,12 @@ public class CheckboxWidgetParameters extends DefaultTouchUIWidgetParameters {
 		this.text = text;
 	}
 	
-	public String getValue() {
-		return value;
+	public boolean[] getChecked() {
+		return checked;
 	}
 
-	public void setValue(String value) {
-		this.value = value;
+	public void setChecked(boolean[] checked) {
+		this.checked = checked;
 	}
 
 	@Override


### PR DESCRIPTION
### Changed the TouchUI CheckBox annotation in two ways:

1. Added the "value" attribute to the annotation so that the touch ui dialog xml will have the attribute. This way it is possible to choose the "checked" value of the checkbox, defaulting to "{Boolean}true".
1. Removed the "checked" attribute from the annotation so that the touch ui dialog xml does not have the attribute. This attribute being set to either true or false implies that "ignoreData" is true. I do not believe that this is what we want from the checkbox fields.

The usage of the different attributes in the touch ui checkbox xml is a bit awkward and unexpected. So if you feel that I might be wrong about this, read the documentation carefully. However I think that we want to set the "value" attribute instead of the "checked" attribute, which is what this pull request does.

#### Relevant documentation:
[Granite Checkbox Documentation](http://docs.adobe.com/docs/en/aem/6-1/ref/granite-ui/api/jcr_root/libs/granite/ui/components/foundation/form/checkbox/index.html)
CRX path to checkbox JSP: /libs/granite/ui/components/foundation/form/checkbox/checkbox.jsp