### PR TITLE
Fix for using namePrefix with multifield

### DIFF
--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/AbstractTouchUIWidget.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/AbstractTouchUIWidget.java
@@ -58,6 +58,10 @@ public class AbstractTouchUIWidget extends AbstractTouchUIDialogElement {
 	public String getName() {
 		return name;
 	}
+	
+	public void setName(String name) {
+		this.name = name;
+	}
 
 	public String getFieldLabel() {
 		return fieldLabel;

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/AbstractTouchUIWidget.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/AbstractTouchUIWidget.java
@@ -58,7 +58,7 @@ public class AbstractTouchUIWidget extends AbstractTouchUIDialogElement {
 	public String getName() {
 		return name;
 	}
-	
+
 	public void setName(String name) {
 		this.name = name;
 	}

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/AbstractTouchUIWidget.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/AbstractTouchUIWidget.java
@@ -59,10 +59,6 @@ public class AbstractTouchUIWidget extends AbstractTouchUIDialogElement {
 		return name;
 	}
 
-	public void setName(String name) {
-		this.name = name;
-	}
-
 	public String getFieldLabel() {
 		return fieldLabel;
 	}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/dialogfieldset/DialogFieldSetWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/dialogfieldset/DialogFieldSetWidgetMaker.java
@@ -105,6 +105,21 @@ public class DialogFieldSetWidgetMaker extends AbstractTouchUIWidgetMaker<Dialog
 
 					double ranking = dialogFieldConfig.getRanking();
 
+					if (StringUtils.isNotBlank(dialogFieldSetAnnotation.namePrefix())) {
+						String name = dialogFieldConfig.getName();
+						String newName;
+						if (name.startsWith("./")) {
+							newName = name.substring(2);
+						} else {
+							newName = name;
+						}
+						newName = dialogFieldSetAnnotation.namePrefix() + newName;
+						if (name.startsWith("./")) {
+							newName = "./" + newName;
+						}
+						dialogFieldConfig.setName(newName);
+					}
+
 					TouchUIWidgetMakerParameters curFieldMember = new TouchUIWidgetMakerParameters();
 					curFieldMember.setDialogFieldConfig(dialogFieldConfig);
 					curFieldMember.setContainingClass(fieldClass);
@@ -112,26 +127,10 @@ public class DialogFieldSetWidgetMaker extends AbstractTouchUIWidgetMaker<Dialog
 					curFieldMember.setClassPool(parameters.getClassPool());
 					curFieldMember.setWidgetRegistry(parameters.getWidgetRegistry());
 					curFieldMember.setUseDotSlashInName(true);
-
+					
 					TouchUIDialogElement currentDialogElement = TouchUIWidgetFactory.make(curFieldMember, -1);
+					
 					if (currentDialogElement != null) {
-						if (currentDialogElement instanceof AbstractTouchUIWidget
-							&& StringUtils.isNotBlank(dialogFieldSetAnnotation.namePrefix())) {
-
-							AbstractTouchUIWidget widget = (AbstractTouchUIWidget) currentDialogElement;
-							String name = widget.getName();
-							String newName;
-							if (name.startsWith("./")) {
-								newName = name.substring(2);
-							} else {
-								newName = name;
-							}
-							newName = dialogFieldSetAnnotation.namePrefix() + newName;
-							if (name.startsWith("./")) {
-								newName = "./" + newName;
-							}
-							widget.setName(newName);
-						}
 						currentDialogElement.setRanking(ranking);
 						elements.add(currentDialogElement);
 					}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/dialogfieldset/DialogFieldSetWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/dialogfieldset/DialogFieldSetWidgetMaker.java
@@ -101,10 +101,6 @@ public class DialogFieldSetWidgetMaker extends AbstractTouchUIWidgetMaker<Dialog
 				}
 
 				if (dialogFieldConfig != null && !dialogFieldConfig.isSuppressTouchUI()) {
-					Class<?> fieldClass = parameters.getClassLoader().loadClass(member.getDeclaringClass().getName());
-
-					double ranking = dialogFieldConfig.getRanking();
-
 					if (StringUtils.isNotBlank(dialogFieldSetAnnotation.namePrefix())) {
 						String name = dialogFieldConfig.getName();
 						String newName;
@@ -121,6 +117,7 @@ public class DialogFieldSetWidgetMaker extends AbstractTouchUIWidgetMaker<Dialog
 					}
 
 					TouchUIWidgetMakerParameters curFieldMember = new TouchUIWidgetMakerParameters();
+					Class<?> fieldClass = parameters.getClassLoader().loadClass(member.getDeclaringClass().getName());
 					curFieldMember.setDialogFieldConfig(dialogFieldConfig);
 					curFieldMember.setContainingClass(fieldClass);
 					curFieldMember.setClassLoader(parameters.getClassLoader());
@@ -131,7 +128,7 @@ public class DialogFieldSetWidgetMaker extends AbstractTouchUIWidgetMaker<Dialog
 					TouchUIDialogElement currentDialogElement = TouchUIWidgetFactory.make(curFieldMember, -1);
 					
 					if (currentDialogElement != null) {
-						currentDialogElement.setRanking(ranking);
+						currentDialogElement.setRanking(dialogFieldConfig.getRanking());
 						elements.add(currentDialogElement);
 					}
 				}


### PR DESCRIPTION
Right now the child field of the MultiField does not get the namePrefix if the MultiField is the child of a DialogFieldSet. Basically, a "bandaid" method was added to allow the name of the DialogFieldSet child to be changed after being created, in order to account for the namePrefix. However, in the case that the child was a MultiField, the MultiField's child's name was not updated.

This is a fix for that issue. Now, the name of the field is updated before creating the child of the DialogFieldSet. That way, in the case that the child is a MultiField, both the MultiField itself and the MultiField's child will receive the namePrefix.