### PR TITLE
Feature: Tab Title Association Support

### DIFF
--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/DialogField.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/DialogField.java
@@ -110,6 +110,17 @@ public @interface DialogField {
 	 * @return int
 	 */
 	public int tab() default 1;
+	
+	/**
+	 * The tab title of the tab in which to place the dialog widget representing 
+	 * the authorable element.
+	 * <p>
+	 * Overrides {@link #tab()} if set. Falls back to {@link #tab()} if tab matching
+	 * title cannot be found.
+	 * 
+	 * @return String
+	 */
+	public String tabTitle() default "";
 
 	/**
 	 * A list of additional properties not already represented by properties of

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/dialog/DialogFieldConfig.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/dialog/DialogFieldConfig.java
@@ -32,6 +32,7 @@ public class DialogFieldConfig {
 	private boolean hideLabel;
 	private String defaultValue;
 	private int tab;
+	private String tabTitle;
 	private Property[] additionalProperties;
 	private Listener[] listeners;
 	private double ranking;
@@ -55,6 +56,7 @@ public class DialogFieldConfig {
 		this.hideLabel = dialogField.hideLabel();
 		this.defaultValue = dialogField.defaultValue();
 		this.tab = dialogField.tab();
+		this.tabTitle = dialogField.tabTitle();
 		this.additionalProperties = dialogField.additionalProperties();
 		this.listeners = dialogField.listeners();
 		this.ranking = dialogField.ranking();
@@ -138,6 +140,14 @@ public class DialogFieldConfig {
 
 	public void setTab(int tab) {
 		this.tab = tab;
+	}
+
+	public String getTabTitle() {
+		return tabTitle;
+	}
+
+	public void setTabTitle(String tabTitle) {
+		this.tabTitle = tabTitle;
 	}
 
 	public Property[] getAdditionalProperties() {

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/factory/DialogFactory.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/factory/DialogFactory.java
@@ -20,13 +20,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javassist.CannotCompileException;
-import javassist.ClassPool;
-import javassist.CtClass;
-import javassist.CtMember;
-import javassist.CtMethod;
-import javassist.NotFoundException;
-
 import org.codehaus.plexus.util.StringUtils;
 
 import com.citytechinc.cq.component.annotations.Component;
@@ -54,8 +47,15 @@ import com.citytechinc.cq.component.dialog.widgetcollection.WidgetCollectionPara
 import com.citytechinc.cq.component.maven.util.ComponentMojoUtil;
 import com.citytechinc.cq.component.maven.util.LogSingleton;
 
-public class DialogFactory {
+import javassist.CannotCompileException;
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtMember;
+import javassist.CtMethod;
+import javassist.NotFoundException;
 
+public class DialogFactory {
+	
 	private static final String DEFAULT_TAB_FIELD_NAME = "tab";
 
 	private DialogFactory() {
@@ -145,8 +145,8 @@ public class DialogFactory {
 					DialogElement builtFieldWidget = WidgetFactory.make(parameters, -1);
 					if (builtFieldWidget != null) {
 						builtFieldWidget.setRanking(dialogFieldConfig.getRanking());
-
-						int tabIndex = dialogFieldConfig.getTab();
+						
+						int tabIndex = getTabIndexForDialogField(dialogFieldConfig, tabsList);
 
 						if (tabIndex < 1 || tabIndex > tabsList.size()) {
 							throw new InvalidComponentFieldException("Invalid tab index " + tabIndex + " for field "
@@ -220,5 +220,23 @@ public class DialogFactory {
 		tabParams.setContainedElements(Arrays.asList(new DialogElement[] { widgetCollection }));
 		tabParams.setListeners(tab.getListeners());
 		return new Tab(tabParams);
+	}
+	
+	private static final int getTabIndexForDialogField(DialogFieldConfig dialogFieldConfig, List<TabHolder> tabsList) {
+		int tabIndex = dialogFieldConfig.getTab();
+		String tabTitle = dialogFieldConfig.getTabTitle();
+		
+		if (StringUtils.isNotBlank(tabTitle)) {
+			for (int i = 0; i < tabsList.size(); i++) {
+				TabHolder tabHolder = tabsList.get(i);
+				String candidateTitle = tabHolder.getTitle();
+				if (tabTitle.equals(candidateTitle)) {
+					tabIndex = i + 1;
+					break;
+				}
+			}
+		}
+		
+		return tabIndex;
 	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/tabs/TabsLayoutMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/tabs/TabsLayoutMaker.java
@@ -51,7 +51,7 @@ import com.citytechinc.cq.component.util.Constants;
 import com.citytechinc.cq.component.xml.XmlElement;
 
 public class TabsLayoutMaker extends AbstractLayoutMaker {
-
+	
 	public TabsLayoutMaker(LayoutMakerParameters parameters) {
 		super(parameters);
 	}
@@ -177,15 +177,17 @@ public class TabsLayoutMaker extends AbstractLayoutMaker {
 				TouchUIDialogElement currentElement = TouchUIWidgetFactory.make(currentWidgetMakerParameters, -1);
 				if (currentElement != null) {
 					currentElement.setRanking(currentWidgetMakerParameters.getDialogFieldConfig().getRanking());
+					
+					int tabIndex = getTabIndexForDialogField(currentWidgetMakerParameters, tabParametersList);
 
-					if (currentWidgetMakerParameters.getDialogFieldConfig().getTab() <= tabParametersList.size()) {
-						tabContentParametersList.get(currentWidgetMakerParameters.getDialogFieldConfig().getTab() - 1)
+					if (tabIndex <= tabParametersList.size()) {
+						tabContentParametersList.get(tabIndex - 1)
 							.addItem(currentElement);
 					} else {
 						throw new LayoutMakerException("Field "
 							+ currentWidgetMakerParameters.getDialogFieldConfig().getName() + " of class "
 							+ currentWidgetMakerParameters.getClass().getName() + " placed in non-existant tab "
-							+ currentWidgetMakerParameters.getDialogFieldConfig().getTab());
+							+ tabIndex);
 					}
 				}
 
@@ -220,5 +222,22 @@ public class TabsLayoutMaker extends AbstractLayoutMaker {
 
 		return new Items(itemsParameters);
 
+	}
+	
+	private static int getTabIndexForDialogField(TouchUIWidgetMakerParameters widgetMakerParameters, List<SectionParameters> sectionParametersList) {
+		int tabIndex = widgetMakerParameters.getDialogFieldConfig().getTab();
+		String tabTitle = widgetMakerParameters.getDialogFieldConfig().getTabTitle();
+		
+		if (StringUtils.isNotBlank(tabTitle)) {
+			for (int i = 0; i < sectionParametersList.size(); i++) {
+				SectionParameters sectionParameters = sectionParametersList.get(i);
+				String candidateTitle = sectionParameters.getTitle();
+				if (tabTitle.equals(candidateTitle)) {
+					tabIndex = i + 1;
+					break;
+				}
+			}
+		}
+		return tabIndex;
 	}
 }


### PR DESCRIPTION
This is a new feature allowing for dialog fields to be associated to a dialog tab by *tab title*. 

Currently dialog field to tab association can only be done via the tab index (number 1-N).

The purpose of this feature is to allow for an inheritance model where parent interfaces or classes define dialog fields that are meant to be shared between multiple components. Using tab index for this purpose does not scale well and is not possible when different components have different numbers of tabs.

*Example Use Case*
We currently use this functionality to share 'Analytics' and 'Background' fields with components. Each component is free to declare as many of its own tabs as necessary (thus making tab index unreliable) yet can also inherit dialog fields for 'Analytics' and 'Background' by declaring the tabs in the @Component annotation and extending/implementing the appropriate Analytics and Background interface/class.

Implementation notes:
- Implemented for both Touch UI and Classic
- Backwards compatible with tab() index field
- New tabTitle() overrides tab() only if set and valid, else tab() value is used.

