### PR TITLE
AEM 6.1 Service Pack 1 datasource issue

### DIFF
--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/selection/SelectionFieldWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/selection/SelectionFieldWidgetMaker.java
@@ -72,9 +72,11 @@ public class SelectionFieldWidgetMaker extends AbstractTouchUIWidgetMaker<Select
 		widgetParameters.setMultiple(getMultipleForField(selectionField));
 		widgetParameters.setDataSource(getDataSourceForField(selectionField));
 
-		widgetParameters.setOptions(TouchUIDialogUtil.getOptionsForSelection(selectionField, getType(),
-			parameters.getClassLoader(), parameters.getClassPool()));
-
+        if(widgetParameters.getDataSource() == null) {
+            widgetParameters.setOptions(TouchUIDialogUtil
+                .getOptionsForSelection(selectionField, getType(), parameters.getClassLoader(),
+                    parameters.getClassPool()));
+        }
 		return new SelectionFieldWidget(widgetParameters);
 	}
 


### PR DESCRIPTION
Previously, the code base generate an "item" node that would make the data source work. The selection drop down field widget would not render any options. By adding a check if a datasource is not null this will prevent the "item" node from being generated.