### PR TITLE
Property annotation change to select touch, classic or both

### DIFF
--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/Property.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/Property.java
@@ -42,11 +42,15 @@ public @interface Property {
 	 */
 	String value();
 	
+	enum RenderValue {
+		BOTH, CLASSIC, TOUCH
+	}
+	
 	/**
 	 * Whether this property should be rendered for the touch, classic, or both.
 	 *
 	 * @return String
 	 */
-	String renderIn() default "both";
+	RenderValue renderIn() default RenderValue.BOTH;
 
 }

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/Property.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/Property.java
@@ -41,5 +41,12 @@ public @interface Property {
 	 * @return String
 	 */
 	String value();
+	
+	/**
+	 * Whether this property should be rendered for the touch, classic, or both.
+	 *
+	 * @return String
+	 */
+	String renderIn() default "both";
 
 }

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/Property.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/Property.java
@@ -47,9 +47,10 @@ public @interface Property {
 	}
 	
 	/**
-	 * Whether this property should be rendered for the touch, classic, or both.
+	 * When used in DialogField.additionalProperties this field will determine 
+	 * whether this property should be rendered for touch UI, classic UI, or both.
 	 *
-	 * @return String
+	 * @return RenderValue
 	 */
 	RenderValue renderIn() default RenderValue.BOTH;
 

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/dialog/DialogFieldConfig.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/dialog/DialogFieldConfig.java
@@ -56,7 +56,7 @@ public class DialogFieldConfig {
 		this.hideLabel = dialogField.hideLabel();
 		this.defaultValue = dialogField.defaultValue();
 		this.tab = dialogField.tab();
-		setAdditionalProperties(dialogField.additionalProperties());
+		this.additionalProperties = dialogField.additionalProperties();
 		this.listeners = dialogField.listeners();
 		this.ranking = dialogField.ranking();
 		this.member = member;

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/dialog/DialogFieldConfig.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/dialog/DialogFieldConfig.java
@@ -17,6 +17,9 @@ package com.citytechinc.cq.component.dialog;
 
 import javassist.CtMember;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.citytechinc.cq.component.annotations.DialogField;
 import com.citytechinc.cq.component.annotations.Property;
 import com.citytechinc.cq.component.annotations.Listener;
@@ -56,7 +59,7 @@ public class DialogFieldConfig {
 		this.hideLabel = dialogField.hideLabel();
 		this.defaultValue = dialogField.defaultValue();
 		this.tab = dialogField.tab();
-		this.additionalProperties = dialogField.additionalProperties();
+		setAdditionalProperties(dialogField.additionalProperties());
 		this.listeners = dialogField.listeners();
 		this.ranking = dialogField.ranking();
 		this.member = member;
@@ -147,7 +150,14 @@ public class DialogFieldConfig {
 	}
 
 	public void setAdditionalProperties(Property[] additionalProperties) {
-		this.additionalProperties = additionalProperties;
+		List<Property> properties = new ArrayList<Property>();
+		for(Property property : additionalProperties) {
+			if ("classic".equals(property.renderIn()) || "both".equals(property.renderIn())) {
+				properties.add(property);
+			}
+		}
+		
+		this.additionalProperties =  properties.toArray(new Property[properties.size()]);
 	}
 
 	public Listener[] getListeners() {

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/dialog/DialogFieldConfig.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/dialog/DialogFieldConfig.java
@@ -17,9 +17,6 @@ package com.citytechinc.cq.component.dialog;
 
 import javassist.CtMember;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.citytechinc.cq.component.annotations.DialogField;
 import com.citytechinc.cq.component.annotations.Property;
 import com.citytechinc.cq.component.annotations.Listener;
@@ -150,14 +147,7 @@ public class DialogFieldConfig {
 	}
 
 	public void setAdditionalProperties(Property[] additionalProperties) {
-		List<Property> properties = new ArrayList<Property>();
-		for(Property property : additionalProperties) {
-			if ("classic".equals(property.renderIn()) || "both".equals(property.renderIn())) {
-				properties.add(property);
-			}
-		}
-		
-		this.additionalProperties =  properties.toArray(new Property[properties.size()]);
+		this.additionalProperties = additionalProperties;
 	}
 
 	public Listener[] getListeners() {

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/dialog/maker/AbstractWidgetMaker.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/dialog/maker/AbstractWidgetMaker.java
@@ -28,6 +28,7 @@ import javassist.NotFoundException;
 import org.codehaus.plexus.util.StringUtils;
 
 import com.citytechinc.cq.component.annotations.Property;
+import com.citytechinc.cq.component.annotations.Property.RenderValue;
 import com.citytechinc.cq.component.annotations.Listener;
 import com.citytechinc.cq.component.dialog.DialogElement;
 import com.citytechinc.cq.component.dialog.Listeners;
@@ -168,7 +169,9 @@ public abstract class AbstractWidgetMaker<T extends WidgetParameters> implements
 			Map<String, String> properties = new HashMap<String, String>();
 
 			for (Property curProperty : parameters.getDialogFieldConfig().getAdditionalProperties()) {
-				properties.put(curProperty.name(), curProperty.value());
+				if (RenderValue.CLASSIC.equals(curProperty.renderIn()) || RenderValue.BOTH.equals(curProperty.renderIn())) {
+					properties.put(curProperty.name(), curProperty.value());
+				}
 			}
 
 			return properties;

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/maker/AbstractTouchUIWidgetMaker.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/maker/AbstractTouchUIWidgetMaker.java
@@ -281,7 +281,9 @@ public abstract class AbstractTouchUIWidgetMaker<T extends TouchUIWidgetParamete
 			Map<String, String> properties = new HashMap<String, String>();
 
 			for (Property curProperty : parameters.getDialogFieldConfig().getAdditionalProperties()) {
-				properties.put(curProperty.name(), curProperty.value());
+				if ("touch".equals(curProperty.renderIn()) || "both".equals(curProperty.renderIn())) {
+					properties.put(curProperty.name(), curProperty.value());
+				}
 			}
 
 			return properties;

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/maker/AbstractTouchUIWidgetMaker.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/maker/AbstractTouchUIWidgetMaker.java
@@ -26,6 +26,7 @@ import javassist.NotFoundException;
 import org.codehaus.plexus.util.StringUtils;
 
 import com.citytechinc.cq.component.annotations.Property;
+import com.citytechinc.cq.component.annotations.Property.RenderValue;
 import com.citytechinc.cq.component.dialog.exception.InvalidComponentFieldException;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
 import com.citytechinc.cq.component.touchuidialog.exceptions.TouchUIDialogGenerationException;
@@ -281,7 +282,7 @@ public abstract class AbstractTouchUIWidgetMaker<T extends TouchUIWidgetParamete
 			Map<String, String> properties = new HashMap<String, String>();
 
 			for (Property curProperty : parameters.getDialogFieldConfig().getAdditionalProperties()) {
-				if ("touch".equals(curProperty.renderIn()) || "both".equals(curProperty.renderIn())) {
+				if (RenderValue.TOUCH.equals(curProperty.renderIn()) || RenderValue.BOTH.equals(curProperty.renderIn())) {
 					properties.put(curProperty.name(), curProperty.value());
 				}
 			}


### PR DESCRIPTION
The `Property` annotation will now be able to select whether it will be generated for touch, classic or both. It will default to both.