### PR TITLE
fix fieldset field names always being prefixed with dot slash which c…

### DIFF
--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/dialogfieldset/DialogFieldSetWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/dialogfieldset/DialogFieldSetWidgetMaker.java
@@ -123,7 +123,7 @@ public class DialogFieldSetWidgetMaker extends AbstractTouchUIWidgetMaker<Dialog
 					curFieldMember.setClassLoader(parameters.getClassLoader());
 					curFieldMember.setClassPool(parameters.getClassPool());
 					curFieldMember.setWidgetRegistry(parameters.getWidgetRegistry());
-					curFieldMember.setUseDotSlashInName(true);
+					curFieldMember.setUseDotSlashInName(parameters.isUseDotSlashInName());
 					
 					TouchUIDialogElement currentDialogElement = TouchUIWidgetFactory.make(curFieldMember, -1);
 					


### PR DESCRIPTION
…auses multicomposite to not work when it's items have a fieldset